### PR TITLE
[20240412] PRG / lv2 / 택배 배달과 수거하기 / 김정환

### DIFF
--- a/Jeonghwan/202504/02 PRG 기능개발.md
+++ b/Jeonghwan/202504/02 PRG 기능개발.md
@@ -1,0 +1,26 @@
+```
+import java.util.*;
+
+class Solution {
+    public int[] solution(int[] progresses, int[] speeds) {
+        List<Integer> answer = new ArrayList<Integer>();
+
+        int days = 0;
+        int idx = 0;
+        while (idx < progresses.length) {
+            int deploy = 0;
+            while (idx < progresses.length &&
+                   progresses[idx] + (speeds[idx] * days) >= 100) {
+                idx++;
+                deploy++;
+            }
+            if (deploy > 0) {
+                answer.add(deploy);
+            }
+            days++;
+        }
+
+        return answer.stream().mapToInt(i -> i).toArray();
+    }
+}
+```

--- a/Jeonghwan/202504/03 PRG 택배 배달과 수거하기.md
+++ b/Jeonghwan/202504/03 PRG 택배 배달과 수거하기.md
@@ -1,0 +1,53 @@
+```
+import java.util.*;
+import java.util.stream.Collectors;
+
+class Solution {
+
+    Deque<Integer> delQue;
+    Deque<Integer> pickQue;
+
+    private void deliver(int cap) {
+        int delCap = cap;
+        int pickCap = cap;
+
+        // 거리가 먼 곳부터 배달, 배달할 물건이 없으면 deque에서 제거
+        while (!delQue.isEmpty() && (delCap > 0 || delQue.peekLast() == 0)) {
+            int last = delQue.pollLast();
+            int val = Math.min(last, delCap);
+            delCap -= val;
+            if (last != val)
+                delQue.offerLast(last - val);
+        }
+        // 거리가 먼 곳부터 회수, 회수할 물건이 없으면 deque에서 제거
+        while (!pickQue.isEmpty() && (pickCap > 0 || pickQue.peekLast() == 0)) {
+            int last = pickQue.pollLast();
+            int val = Math.min(last, pickCap);
+            pickCap -= val;
+            if (last != val)
+                pickQue.offerLast(last - val);
+        }
+    }
+
+    public long solution(int cap, int n, int[] deliveries, int[] pickups) {
+        delQue = new LinkedList<Integer>(Arrays.stream(deliveries)
+                                             .boxed()
+                                             .collect(Collectors.toList()));
+        pickQue = new LinkedList<Integer>(Arrays.stream(pickups)
+                                             .boxed()
+                                             .collect(Collectors.toList()));
+
+        // 배열 마지막에 배달,회수할 물건이 0이면 제거해줘야함
+        deliver(0);
+
+        long answer = 0;
+        while (!delQue.isEmpty() || !pickQue.isEmpty()) {
+            // 배달 또는 회수할 물건이 있는 목적지 중 더 먼곳을 기준으로 이동거리 추가(왕복이기 때문에 2배)
+            answer += Math.max(delQue.size(), pickQue.size()) * 2;
+            pop(cap);
+        }
+
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 📌 문제 제목

- 문제 링크 : [택배 배달과 수거하기](https://school.programmers.co.kr/learn/courses/30/lessons/150369)

## 📝 문제 풀이

💡 아이디어 및 접근 방법

- 배달할 물건, 회수할 물건을 가장 먼거리부터 차례대로 배달 및 회수하면 이동거리의 최소거리를 알 수 있음
- cap은 배달, 회수할 수 있는 물건의 최댓값 -> 각 배열의 뒤에서부터 요소를 제거할 때 한번에 제거할 수 있는 max값으로 사용
- 택배 차량이 한번 이동할 때마다 배달, 회수할 물건 중 가장 먼거리 위치까지 왕복함
- 시간복잡도는 (배달할 물건 총 갯수 / capacity), (회수할 물건 총 갯수 / capacity) 둘 중 더 큰값
  - n의 최댓값: 100,000
  - delieveries, pickups 각 원소의 최댓값 : 50
  - capacity 최솟값 : 1
  - 이론상 각 시간복잡도는 5,000,000이다.

## ⏰ 수행 시간

- 60분

## 🫡 시간 인증
<img width="990" alt="image" src="https://github.com/user-attachments/assets/7674ad80-a96d-47b8-94e1-4aa9ae3a0674" />

## ✅ 시간 복잡도

- O(N)
