### PR TITLE
[20250420] PRG / lv2 / 조이스틱 / 진종환

### DIFF
--- a/jonghwan/202504/03 PRG 조이스틱.md
+++ b/jonghwan/202504/03 PRG 조이스틱.md
@@ -1,0 +1,33 @@
+```js
+function solution(name) {
+  let updown = 0;
+  let move = name.length - 1;
+  let Aindex = 0;
+  let AtoZ = Array(name.length).fill('A').join('');
+
+  for (let i = 0; i < name.length; i++) {
+    let asciiName = name.charCodeAt(i);
+    let asciiChar = AtoZ.charCodeAt(i);
+
+    if (asciiName <= 78) {
+      updown += asciiName - asciiChar;
+    } else {
+      updown += 91 - asciiName;
+    }
+
+    // A 위치 기억하기
+    Aindex = i;
+    while (name.at(Aindex) == 'A') {
+      Aindex += 1;
+    }
+
+    if (i == 0) {
+      move = Math.min(name.length - Aindex, move);
+    } else {
+      move = Math.min(2 * (i - 1) + name.length - Aindex, move);
+      move = Math.min(move, i - 1 + (name.length - Aindex) * 2);
+    }
+  }
+  return updown + move;
+}
+```


### PR DESCRIPTION
## 📌 문제 링크
- 프로그래머스 : [구명보트](https://school.programmers.co.kr/learn/courses/30/lessons/42885)

<br>

## 📍문제 접근
- 아스키 코드로 바꾼 알파벳과 처음 A로 지정해준 문자열과 비교해서 차이만큼을 더함
- 주의할 점은 알파벳 중간지점 ("M") 뒤로는 뒤에서 부터 가는 것이 더 적게 이동할 수 있는 방법이기 때문에 91에서 빼주는 방법으로 계산 
- 그 후에 순서대로 가는 것과 뒤로 돌아가는 것 중 이동 수가 적은 것을 선택. 만약 연속된 A의 앞쪽보다 뒷쪽이 짧은 경우, 뒷쪽부터 조작

<br>

## ⏳ 수행 시간
- 1시간

<br>

## ✅ 테스트 인증
![image](https://github.com/user-attachments/assets/afae1b41-aae9-4b86-8ab7-b2d88381e5f6)


<br>

## ⏰ 시간 복잡도
- 풀이 시간 복잡도 명시
