### PR TITLE
[20250612] PRG / 골드3 / 벽 부수고 이동하기 / 모창일

### DIFF
--- a/ChangIl/202506/01 BOJ RGB거리.java
+++ b/ChangIl/202506/01 BOJ RGB거리.java
@@ -1,0 +1,60 @@
+import java.util.*;
+import java.io.*;
+import java.lang.Math;
+
+class Main{
+    public static int solution(int n, int[][] arr){
+
+        int[][] dp = new int[n][3];
+
+        for (int i = 1 ; i < n ; i++){
+            arr[i][0] += Math.min(arr[i-1][1], arr[i-1][2]);
+            arr[i][1] += Math.min(arr[i-1][0], arr[i-1][2]);
+            arr[i][2] += Math.min(arr[i-1][0], arr[i-1][1]);
+        }
+
+        Arrays.sort(arr[n-1]);
+        return(arr[n-1][0]);
+    }
+
+
+
+    public static void main(String[] args) throws IOException{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] arr = new int[n][3];
+
+
+        for (int i = 0 ; i < n ; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            arr[i][0] = Integer.parseInt(st.nextToken());
+            arr[i][1] = Integer.parseInt(st.nextToken());
+            arr[i][2] = Integer.parseInt(st.nextToken());
+        }
+
+        System.out.println(solution(n, arr));
+
+    }
+}
+
+/*
+
+집 N
+거리 선분
+빨, 초, 파 (각 집마다 비용있음)
+
+1번집 != 2번집
+N번집 != N-1번집
+i번집은 양옆에 같으면 안됨
+
+
+dpw[i][3] = 현재까지 비용의 최소값인데, 0 선택했을때, 1 선택했을때, 2 선택했을때
+dpc[i] = 현재 집의 컬러
+dpc[i] = dp[i-1]
+
+걍 다구하기? 제약조건 생각보다 괜찮음
+
+ */

--- a/ChangIl/202506/02 BOJ 벽 부수고 이동하기.java
+++ b/ChangIl/202506/02 BOJ 벽 부수고 이동하기.java
@@ -1,0 +1,101 @@
+import java.io.*;
+import java.util.*;
+
+
+
+class Main{
+
+    static class Node{
+        int x,y,count;
+        boolean hasUsed;
+
+
+        Node(int x, int y, int count, boolean hasUsed){
+            this.x = x;
+            this.y = y;
+            this.hasUsed = hasUsed;
+            this.count = count;
+        }
+    }
+
+    public static int bfs(int[][] gameMap, int n , int m){
+
+        int[][] dir =  {{0,1}, {1,0}, {-1,0}, {0,-1}};
+        int[][][] visited = new int[n][m][2];
+        visited[0][0][0] = 1;
+
+        int answer = Integer.MAX_VALUE;
+
+        Deque<Node> deque = new LinkedList<>();
+        deque.add(new Node(0,0,1,false));
+        while(!deque.isEmpty()){
+            Node node = deque.remove();
+            if (node.x == n-1 && node.y == m-1){
+                return node.count;
+            }
+            for(int i = 0; i < 4 ; i++){
+                int nx = dir[i][0] + node.x;
+                int ny = dir[i][1] + node.y;
+                if(nx < 0 || ny < 0 || nx > n-1 || ny > m-1) { continue; }
+                if(gameMap[nx][ny] == 0){
+                    if(node.hasUsed == true){
+                        if(visited[nx][ny][0] == 0 && visited[nx][ny][1] == 0){
+                            deque.add(new Node(nx,ny,node.count+1,true));
+                            visited[nx][ny][1] = 1;
+                        }
+                    } else{
+                        if(visited[nx][ny][0] == 0){
+                            deque.add(new Node(nx,ny,node.count+1,false));
+                            visited[nx][ny][0] = 1;
+                        }
+                    }
+                }else{
+                    if(node.hasUsed == false && visited[nx][ny][0] == 0){
+                        deque.add(new Node(nx,ny,node.count+1,true));
+                        visited[nx][ny][1] = 1;
+                    }
+                }
+
+            }
+        }
+        return -1;
+    }
+
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[][] gameMap = new int[n][m];
+
+        for (int i = 0 ; i < n ; i++){
+            String str = (br.readLine());
+            for (int j = 0 ; j < m ; j++){
+                gameMap[i][j] = str.charAt(j) - '0';
+            }
+        }
+
+        System.out.println(bfs(gameMap,n,m));
+    }
+}
+
+
+/*
+다음 이동 가능한 노드를 상하좌우 및 벽깨기까지 5개의 방향이 있다고 가정하는건 어떨까
+
+그렇게 가정했을때 벽 깨기 상태는 어떻게 저장?
+1. 전역변수로 저장
+2. 벽 깰수있는 상태도 큐에 담아서 전달
+
+1. 전역변수로 저장했을때, 상태 관리가 너무 힘듬.
+2. 벽 깰수있는 상태를 큐에 담아서 전달하면, 현재 index에서 독립적으로 판단가능
+2-1. 벽을 깨고 방문한 곳은 visited check를 2로 저장해서 visited 2면 방문할 수 있도록 하기
+2-2. 즉 gamemap[nx][ny] = 0 or 2라면 gamemap[nx][ny]로 방문 가능 (이때는 gamemap[nx][ny] = 1로 변경하기)
+2-3. gamemap[nx][ny] = 1 이고 hasUsed = false라면 gamemap[nx][ny] = 2로 설정하고 hasUsed = true로 변경
+2-*. gamemap 자체를 visited 처리해버리면 bfs 경로중 다른 가지에서의 상태 변경이 또다른 가지의 상태에 영향을 주기에, visited 배열을 따로 사용하자
+
+*. 벽을 깼을때와 깨지 않았을때의 상태는 전혀 다른 상태. 전혀 다른 gameMap이 됨을 인지해야함. 벽을 깬지, 안깬지의 방문했는지 안했는지를 확인함으로써 구분
+ */
+


### PR DESCRIPTION
## 📌 문제 링크
- 백준 : https://www.acmicpc.net/problem/2206

<br>

## 📍문제 접근
- 최단경로를 찾는 문제인데, 한번 벽을 부수고 이동할 수 있다.
- 벽을 부순 후의 최단경로는, 벽을 부수기 전과의 최단경로와 완전히 다른 경로
  - 벽을 부수고 방문한 좌표는 벽을 부수고 방문할 좌표가 될 수 있다.
    - visited[nx][ny][0] : 벽을 부수지 않고 좌표의 방문여부
    - visited[nx][ny][1] : 벽을 부순후 좌표의 방문여부
- bfs를 도입하는데, 현재 노드에서 다음 노드를 찾는 방법이 상하좌우 외에도 "벽을 부수기"가 존재하도록 함
  - 큐에 넣는 노드의 구성요소로 "벽을 부쉈는지" 여부도 전달하도록 함

<br>

## ⏳ 수행 시간
- 1시간

<br>

## ✅ 테스트 인증
<img width="734" alt="image" src="https://github.com/user-attachments/assets/545290a8-5e74-414a-a248-014b7370c63c" />


<br>

## ⏰ 시간 복잡도
O(nm)
